### PR TITLE
Remove invalid precision check

### DIFF
--- a/src/erlvolt_wire.erl
+++ b/src/erlvolt_wire.erl
@@ -827,7 +827,6 @@ volt_decimal(E) when (is_integer(E) or is_float(E)), E >= ?VOLT_DECIMAL_MIN,
 
     D = E * ?VOLT_DECIMALS_SCALESHIFT,
     T = trunc(D),
-    if D /= T -> throw(loosing_precision); true -> nil end, %%% @doc will not happen.
 
     ?VOLT_DECIMAL_BINARY_TYPE(T).
 


### PR DESCRIPTION
Check was removed becase it triggered false alarm.

Condider the following test case, that  caused exception to be incorrectly thrown:

```
X = -1.09 * ?VOLT_DECIMALS_SCALESHIFT,
X =/= trunc(X) %% is true
```

While X is definately fits into the BigDecimal, it gets corrupted (due to float nature) when expanded.
It is clear, that value _should_ still be written to the database despite of some (falsy) precision lost diagnostics
